### PR TITLE
LIBFCREPO-1238. Minor refactoring of the find command and added tests.

### DIFF
--- a/plastron-cli/tests/commands/test_find.py
+++ b/plastron-cli/tests/commands/test_find.py
@@ -1,8 +1,10 @@
+from argparse import Namespace
+
 import httpretty
 import pytest
 from rdflib import Graph, Literal
 
-from plastron.cli.commands.find import find
+from plastron.cli.commands.find import find, Command
 from plastron.namespaces import rdf, pcdm, dcterms, ldp
 
 
@@ -16,8 +18,7 @@ from plastron.namespaces import rdf, pcdm, dcterms, ldp
     ]
 )
 @httpretty.activate
-def test_find(datadir, repo, register_root, simulate_repo, matcher, properties, expected_count):
-    register_root()
+def test_find(datadir, repo, simulate_repo, matcher, properties, expected_count):
     graph = Graph().parse(file=(datadir / 'graph.ttl').open())
     simulate_repo(graph)
     resources = list(find(
@@ -27,3 +28,57 @@ def test_find(datadir, repo, register_root, simulate_repo, matcher, properties, 
         properties=properties,
     ))
     assert len(resources) == expected_count
+
+
+@pytest.mark.parametrize(
+    ('args', 'expected_paths'),
+    [
+        (
+            Namespace(
+                recursive='ldp:contains',
+                data_properties=[],
+                object_properties=[],
+                types=[],
+                match_all=True,
+                match_any=False,
+                uris=['/container'],
+            ),
+            ['/container', '/container/1', '/container/2'],
+        ),
+        (
+            Namespace(
+                recursive='ldp:contains',
+                data_properties=[],
+                object_properties=[],
+                types=['pcdm:Object'],
+                match_all=True,
+                match_any=False,
+                uris=['/container'],
+            ),
+            ['/container/1']
+        ),
+        (
+            Namespace(
+                recursive='ldp:contains',
+                data_properties=[('dcterms:title', 'Moonpig')],
+                object_properties=[],
+                types=['pcdm:Object'],
+                match_all=False,
+                match_any=True,
+                uris=['/container'],
+            ),
+            ['/container/1', '/container/2']
+        ),
+    ]
+)
+@httpretty.activate
+def test_find_command(capsys, datadir, repo, simulate_repo, args, expected_paths):
+    graph = Graph().parse(file=(datadir / 'graph.ttl').open())
+    simulate_repo(graph)
+    cmd = Command()
+    cmd.repo = repo
+    cmd(client=repo.client, args=args)
+    captured = capsys.readouterr()
+    assert len(captured.out.splitlines()) == len(expected_paths)
+    for path in expected_paths:
+        assert f'http://localhost:9999{path}\n' in captured.out

--- a/plastron-cli/tests/commands/test_find/graph.ttl
+++ b/plastron-cli/tests/commands/test_find/graph.ttl
@@ -1,6 +1,11 @@
+@base <http://localhost:9999/> .
+
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ldp: <http://www.w3.org/ns/ldp#> .
 @prefix pcdm: <http://pcdm.org/models#> .
 
-<http://example.com/test_find/1> a pcdm:Object; dcterms:title "Foobar" .
+<container> ldp:contains <container/1>, <container/2> .
 
-<http://example.com/test_find/2> dcterms:title "Moonpig" .
+<container/1> a pcdm:Object; dcterms:title "Foobar" .
+
+<container/2> dcterms:title "Moonpig" .

--- a/plastron-cli/tests/commands/test_list.py
+++ b/plastron-cli/tests/commands/test_list.py
@@ -1,0 +1,32 @@
+from argparse import Namespace
+
+import httpretty
+from rdflib import Graph
+
+from plastron.cli.commands.list import Command
+
+
+@httpretty.activate
+def test_list_command(capsys, datadir, repo, simulate_repo):
+    graph = Graph().parse(file=(datadir / 'graph.ttl').open())
+    simulate_repo(graph)
+    cmd = Command()
+    cmd.repo = repo
+    cmd(client=repo.client, args=Namespace(long=False, uris=['/container']))
+    captured = capsys.readouterr()
+    assert len(captured.out.splitlines()) == 2
+    assert f'http://localhost:9999/container/1\n' in captured.out
+    assert f'http://localhost:9999/container/2\n' in captured.out
+
+
+@httpretty.activate
+def test_list_long_command(capsys, datadir, repo, simulate_repo):
+    graph = Graph().parse(file=(datadir / 'graph.ttl').open())
+    simulate_repo(graph)
+    cmd = Command()
+    cmd.repo = repo
+    cmd(client=repo.client, args=Namespace(long=True, uris=['/container']))
+    captured = capsys.readouterr()
+    assert len(captured.out.splitlines()) == 2
+    assert f'http://localhost:9999/container/1 Foobar\n' in captured.out
+    assert f'http://localhost:9999/container/2 Moonpig\n' in captured.out

--- a/plastron-cli/tests/commands/test_list/graph.ttl
+++ b/plastron-cli/tests/commands/test_list/graph.ttl
@@ -1,0 +1,11 @@
+@base <http://localhost:9999/> .
+
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ldp: <http://www.w3.org/ns/ldp#> .
+@prefix pcdm: <http://pcdm.org/models#> .
+
+<container> ldp:contains <container/1>, <container/2> .
+
+<container/1> a pcdm:Object; dcterms:title "Foobar" .
+
+<container/2> dcterms:title "Moonpig" .

--- a/plastron-cli/tests/conftest.py
+++ b/plastron-cli/tests/conftest.py
@@ -55,12 +55,13 @@ def register_root(endpoint: Endpoint):
 
 
 @pytest.fixture
-def simulate_repo() -> Callable[[Graph], None]:
+def simulate_repo(register_root) -> Callable[[Graph], None]:
     """Pytest fixture that uses HTTPretty to simulate a read-only repository.
     The repository is defined using a Graph. Each unique subject in that graph
     is assumed to be its own resource. Each resource will respond to HEAD and
     GET requests with 200 OK and Content-Type application/n-triples."""
     def _register_repo(graph: Graph):
+        register_root()
         subjects = set(graph.subjects())
         for subject in subjects:
             resource_graph = Graph()

--- a/plastron-cli/tests/conftest.py
+++ b/plastron-cli/tests/conftest.py
@@ -1,8 +1,10 @@
 import re
+from typing import Callable
 from uuid import uuid4
 
 import pytest
 from httpretty import httpretty
+from rdflib import Graph
 
 from plastron.client import Endpoint, Client
 from plastron.client.auth import get_authenticator
@@ -50,6 +52,39 @@ def register_root(endpoint: Endpoint):
             status=status,
         )
     return _register_root
+
+
+@pytest.fixture
+def simulate_repo() -> Callable[[Graph], None]:
+    """Pytest fixture that uses HTTPretty to simulate a read-only repository.
+    The repository is defined using a Graph. Each unique subject in that graph
+    is assumed to be its own resource. Each resource will respond to HEAD and
+    GET requests with 200 OK and Content-Type application/n-triples."""
+    def _register_repo(graph: Graph):
+        subjects = set(graph.subjects())
+        for subject in subjects:
+            resource_graph = Graph()
+            for triple in graph.triples((subject, None, None)):
+                resource_graph.add(triple)
+            body = resource_graph.serialize(format='application/n-triples')
+            httpretty.register_uri(
+                method=httpretty.HEAD,
+                uri=subject,
+                status=200,
+                adding_headers={
+                    'Content-Type': 'application/n-triples',
+                },
+            )
+            httpretty.register_uri(
+                method=httpretty.GET,
+                uri=subject,
+                status=200,
+                body=body,
+                adding_headers={
+                    'Content-Type': 'application/n-triples',
+                },
+            )
+    return _register_repo
 
 
 @pytest.fixture


### PR DESCRIPTION
- Split a core find() function out of the find Command class
- Created a simulate_repo() test fixture to mock a (read-only) repo using a graph
- Added tests of the find and list commands

https://umd-dit.atlassian.net/browse/LIBFCREPO-1238